### PR TITLE
feat: automatically configure Nix to use cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   token:
     description: "Attic authorization token"
     required: false
+  skip-use:
+    description: "Set to true to skip using attic cache as a substituter"
+    required: false
 
 runs:
   using: "node16"

--- a/src/stages/configure.ts
+++ b/src/stages/configure.ts
@@ -9,9 +9,17 @@ export const configure = async () => {
 		const endpoint = core.getInput("endpoint");
 		const cache = core.getInput("cache");
 		const token = core.getInput("token");
+		const skipUse = core.getInput("skip-use");
 
 		core.info("Logging in to attic cache");
 		await exec("attic", ["login", "--set-default", cache, endpoint, token]);
+
+		if (skipUse === "true") {
+			core.info('Not adding attic cache to substituters as skip-use is set to true');
+		} else {
+			core.info("Adding attic cache to substituters");
+			await exec.exec('attic', ['use', cache]);
+		}
 
 		core.info("Collecting store paths before build");
 		await saveStorePaths();


### PR DESCRIPTION
Automatically call `attic use ...`, so that the CI pipeline will actually use the cache and not rebuild everything that is already cached all the time.

Inspired by the way the cachix actions handles it, which also _uses_ the cache by default.