### PR TITLE
push: don't report failure on error

### DIFF
--- a/src/stages/push.ts
+++ b/src/stages/push.ts
@@ -32,7 +32,8 @@ export const push = async () => {
 			}
 		}
 	} catch (e) {
-		core.setFailed(`Action failed with error: ${e}`);
+		core.warning(`Action encountered error: ${e}`);
+		core.info("Not considering errors during push a failure.");
 	}
 
 	core.endGroup();


### PR DESCRIPTION
uploads aren't necessary in most scenarios, and failures unrelated to the job are a bit annoying to deal with. this is similar to what [magic-nix-cache](https://github.com/DeterminateSystems/magic-nix-cache-action) does