### PR TITLE
fix: support nix >= 2.19

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,5 +6,5 @@ export const saveStorePaths = async () => {
 	await exec("sh", ["-c", "nix path-info --all --json > /tmp/store-paths"]);
 };
 export const getStorePaths = async () => {
-	return (JSON.parse(await readFile("/tmp/store-paths", "utf8")) as { path: string }[]).map((path) => path.path);
+	return Object.keys(JSON.parse(await readFile("/tmp/store-paths", "utf8")) as { path: string }[]);
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,5 +6,12 @@ export const saveStorePaths = async () => {
 	await exec("sh", ["-c", "nix path-info --all --json > /tmp/store-paths"]);
 };
 export const getStorePaths = async () => {
-	return Object.keys(JSON.parse(await readFile("/tmp/store-paths", "utf8")) as { path: string }[]);
+	const rawStorePaths = JSON.parse(await readFile("/tmp/store-paths", "utf8")) as { path: string }[];
+
+	// compatibility with Nix 2.18
+	if (Array.isArray(rawStorePaths)) {
+		return rawStorePaths.map((path) => path.path); 
+	};
+
+	return Object.keys(rawStorePaths);
 };


### PR DESCRIPTION
Keep in mind that I have never wrote a single line of JavaScript/TypeScript. Not sure if this is a viable solution, but it works for me.

`nix path-info --all --json` returns a JSON object, with the keys being Nix store paths and the values being extra information associated with that Nix store path. I replaced the .map (on an object instead of an array, hence the error) with Object.keys() to get the store paths only.

Closes #17.