### PR TITLE
feat: skip installation of attic when installed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,16 @@
-import { install } from "./stages/install";
+import { install, isInstalled } from "./stages/install";
 import { configure } from "./stages/configure";
 import { push } from "./stages/push";
-import { getState, saveState } from "@actions/core";
+import { getState, saveState, info } from "@actions/core";
 
 const isPost = !!getState("isPost");
 
 const main = async () => {
-	await install();
+	if (await isInstalled()) {
+		info("Skipping attic installation because it is already installed");
+	} else {
+		await install();
+	}
 	await configure();
 };
 

--- a/src/stages/install.ts
+++ b/src/stages/install.ts
@@ -33,3 +33,8 @@ export const install = async () => {
 
 	core.endGroup();
 };
+
+export const isInstalled = async () => {
+	let return_code = await exec("attic", ["-V"]);
+	return return_code === 0;
+};


### PR DESCRIPTION
This PR adds a check to skip the installation of `attic` when `attic -V` returns with exit code 0.

Closes #20